### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/FrankBurmo/bookwriter/security/code-scanning/1](https://github.com/FrankBurmo/bookwriter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow. This ensures that the workflow has only the minimal permissions required to perform its tasks, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
